### PR TITLE
🔀 :: (#50) add student info list item

### DIFF
--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
@@ -74,13 +74,15 @@ fun DotoriStudentInfoListItem(
                 style = DotoriTheme.typography.smallTitle,
                 color = DotoriTheme.colors.neutral10
             )
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
                 Text(
                     text = studentId,
                     style = DotoriTheme.typography.smallTitle,
                     color = DotoriTheme.colors.neutral20
                 )
-                Spacer(modifier = Modifier.width(3.dp))
                 if (gender == GenderType.MAN.toString()) {
                     MaleIcon(
                         modifier = Modifier.size(14.dp),

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
@@ -149,13 +149,6 @@ fun DotoriStudentInfoListItemPreview() {
             imageUrl = "",
             name = "김준",
             studentId = "1101",
-            gender = "MAN",
-            role = "ROLE_ADMIN"
-        ) {}
-        DotoriStudentInfoListItem(
-            imageUrl = "",
-            name = "김준",
-            studentId = "1101",
             gender = "WOMAN",
             role = "ROLE_MEMBER"
         ) {}

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
@@ -1,0 +1,163 @@
+package com.dotori.dotori_components.components.student_info
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.role.DotoriRoleBadge
+import com.dotori.dotori_components.components.utils.GenderType
+import com.dotori.dotori_components.theme.DotoriTheme
+import com.dotori.dotori_components.theme.FemaleIcon
+import com.dotori.dotori_components.theme.MaleIcon
+import com.dotori.dotori_components.theme.MeatballIcon
+import com.dotori.dotori_components.theme.White
+import com.example.dus.R
+import com.skydoves.landscapist.glide.GlideImage
+
+@Composable
+fun DotoriStudentInfoListItem(
+    modifier: Modifier = Modifier,
+    imageUrl: String,
+    name: String,
+    studentId: String,
+    gender: String,
+    role: String,
+    onOptionClicked: () -> Unit
+) {
+    var isClicked by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = if (isClicked) DotoriTheme.colors.background else DotoriTheme.colors.cardBackground,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(
+                horizontal = 8.dp,
+                vertical = 16.dp
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        GlideImage(
+            modifier = Modifier
+                .clip(CircleShape)
+                .size(40.dp),
+            imageModel = { imageUrl },
+            previewPlaceholder = R.drawable.ic_dotori,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = name,
+                style = DotoriTheme.typography.smallTitle,
+                color = DotoriTheme.colors.neutral10
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = studentId,
+                    style = DotoriTheme.typography.smallTitle,
+                    color = DotoriTheme.colors.neutral20
+                )
+                Spacer(modifier = Modifier.width(3.dp))
+                if (gender == GenderType.MAN.toString()) {
+                    MaleIcon(
+                        modifier = Modifier.size(14.dp),
+                        contentDescription = "MaleIcon",
+                        tint = DotoriTheme.colors.neutral20
+                    )
+                } else {
+                    FemaleIcon(
+                        modifier = Modifier.size(14.dp),
+                        contentDescription = "FemaleIcon",
+                        tint = DotoriTheme.colors.neutral20
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.width(36.dp))
+        DotoriRoleBadge(role = role)
+        Spacer(modifier = Modifier.weight(1f))
+        MeatballIcon(
+            modifier = Modifier.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = {
+                    isClicked = !isClicked
+                    onOptionClicked()
+                }
+            ),
+            contentDescription = "MeatballIcon",
+            tint = DotoriTheme.colors.neutral30
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DotoriStudentInfoListItemPreview() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        DotoriStudentInfoListItem(
+            imageUrl = "",
+            name = "김준",
+            studentId = "1101",
+            gender = "MAN",
+            role = "ROLE_MEMBER",
+        ) {}
+        DotoriStudentInfoListItem(
+            imageUrl = "",
+            name = "김준",
+            studentId = "1101",
+            gender = "MAN",
+            role = "ROLE_DEVELOPER"
+        ) {}
+        DotoriStudentInfoListItem(
+            imageUrl = "",
+            name = "김준",
+            studentId = "1101",
+            gender = "MAN",
+            role = "ROLE_COUNCILLOR"
+        ) {}
+        DotoriStudentInfoListItem(
+            imageUrl = "",
+            name = "김준",
+            studentId = "1101",
+            gender = "MAN",
+            role = "ROLE_ADMIN"
+        ) {}
+        DotoriStudentInfoListItem(
+            imageUrl = "",
+            name = "김준",
+            studentId = "1101",
+            gender = "WOMAN",
+            role = "ROLE_MEMBER"
+        ) {}
+    }
+}

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/student_info/DotoriStudentInfoListItem.kt
@@ -65,7 +65,7 @@ fun DotoriStudentInfoListItem(
                 .clip(CircleShape)
                 .size(40.dp),
             imageModel = { imageUrl },
-            previewPlaceholder = R.drawable.ic_dotori,
+            previewPlaceholder = R.drawable.ic_profile_light,
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {


### PR DESCRIPTION
### 개요
- DotoriStudentInfoListItem 구현

### 디자인
<img width="400" alt="image" src="https://github.com/Team-Ampersand/DUS/assets/84944098/3471b79c-edf5-4199-b8b5-2ee9ee29a55f">

### 구현화면
<img width="400" alt="스크린샷 2023-08-29 오전 10 09 18" src="https://github.com/Team-Ampersand/DUS/assets/84944098/ce475b45-1721-420d-ab02-53aea4a473d1">

### 구현영상
https://github.com/Team-Ampersand/DUS/assets/84944098/0518ec0f-c513-4b68-8396-fb88ae4c8bbd

### 기타사항
- 성별을 나타내는 아이콘 크기를 정확히 알 수 없어서 임의로 14.dp로 조정했습니다! 
- 크기를 더 작거나 크게 키울까요?
