### PR TITLE
🔀 :: (#71) modify dotori bottom sheet dialog component

### DIFF
--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -1,12 +1,16 @@
 package com.dotori.dotori_components.components.bottomsheet
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.button.DotoriButton
 import com.dotori.dotori_components.theme.DotoriTheme
 import kotlinx.coroutines.*
 
@@ -37,5 +41,30 @@ fun DotoriBottomSheetDialog(
         sheetShape = sheetShape
     ) {
         content(sheetState)
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Preview
+@Composable
+fun DotoriBottomSheetDialogPreview() {
+    val coroutineScope = rememberCoroutineScope()
+
+    DotoriBottomSheetDialog(
+        sheetContent = {
+            Text(text = "test")
+        }
+    ) { sheetState ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(DotoriTheme.colors.background)
+        ) {
+            DotoriButton(text = "show") {
+                coroutineScope.launch {
+                    sheetState.show()
+                }
+            }
+        }
     }
 }

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -28,7 +28,7 @@ fun DotoriBottomSheetDialog(
     ModalBottomSheetLayout(
         modifier = modifier,
         sheetState = sheetState,
-        sheetContent = { sheetContent() },
+        sheetContent = sheetContent,
         sheetBackgroundColor = sheetBackgroundColor,
         sheetShape = sheetShape
     ) {

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -28,15 +28,7 @@ fun DotoriBottomSheetDialog(
     ModalBottomSheetLayout(
         modifier = modifier,
         sheetState = sheetState,
-        sheetContent = {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 32.dp)
-            ) {
-                sheetContent()
-            }
-        },
+        sheetContent = { sheetContent() },
         sheetBackgroundColor = sheetBackgroundColor,
         sheetShape = sheetShape
     ) {

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.theme.DotoriTheme
 import kotlinx.coroutines.*
@@ -16,34 +15,27 @@ import kotlinx.coroutines.*
 fun DotoriBottomSheetDialog(
     modifier: Modifier = Modifier,
     sheetShape: Shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-    sheetPeekHeight: Dp = 0.dp,
-    sheetTopContent: @Composable ColumnScope.() -> Unit,
-    sheetBottomContent: @Composable ColumnScope.() -> Unit,
-    content: @Composable (sheetState: BottomSheetState) -> Unit
+    sheetContent: @Composable ColumnScope.() -> Unit,
+    content: @Composable (sheetState: ModalBottomSheetState) -> Unit
 ) {
     val sheetBackgroundColor = DotoriTheme.colors.cardBackground
-    val sheetState = rememberBottomSheetState(initialValue = BottomSheetValue.Collapsed)
-    val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
+    val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
 
-    BottomSheetScaffold(
+    ModalBottomSheetLayout(
         modifier = modifier,
-        scaffoldState = scaffoldState,
+        sheetState = sheetState,
         sheetContent = {
             Column(
                 modifier = modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 32.dp)
             ) {
-                sheetTopContent()
-                Spacer(modifier = modifier.height(32.dp))
-                sheetBottomContent()
+                sheetContent()
             }
         },
-        sheetPeekHeight = sheetPeekHeight,
         sheetBackgroundColor = sheetBackgroundColor,
         sheetShape = sheetShape
     ) {
         content(sheetState)
     }
 }
-


### PR DESCRIPTION
## 💡 개요
- DotoriBottomSheetDialog 컴포넌트 수정

## 🔀 작업내용
- BottomSheetScaffold를 ModalBottomSheetLayout으로 변경
- sheetContent를 하나만 받도록 수정
- `@Preview` 추가

## 🎸 기타
- Dotori에서 사용될 뷰와 background blur 등을 고려해서 ModalBottomSheetLayout로 변경했습니다

## 구현화면
<img width="328" alt="스크린샷 2023-09-07 오후 12 00 59" src="https://github.com/Team-Ampersand/DUS/assets/85855341/3af5ab97-1e24-4872-a3fe-f594ca8ff3cd">
<img width="333" alt="스크린샷 2023-09-07 오전 11 59 09" src="https://github.com/Team-Ampersand/DUS/assets/85855341/954759a9-d720-4769-8e18-db5424afe77a">