### PR TITLE
🔀 :: (#74) dotori bottom sheet null value exception

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -9,7 +9,7 @@ object Versions {
 
     const val COMPOSE_VERSION = "1.3.1"
     const val ACTIVITY_COMPOSE = "1.6.1"
-    const val MATERIAL_COMPOSE = "1.3.1"
+    const val MATERIAL_COMPOSE = "1.4.0-alpha04"
     const val NAVIGATION_COMPOSE = "2.5.3"
     const val PAGER_COMPOSE = "0.28.0"
     const val LANDSCAPIST_COMPOSE = "2.1.2"


### PR DESCRIPTION
## 💡 개요
- DotoriBottomSheetDialog가 빈 컴포넌트(null) 일 때 예외가 발생

## 🔀 작업내용
- 해당 오류가 수정된 버전으로 Material Compose version up

## 🎸 기타
