### PR TITLE
🔀 :: (#78) add skip half expanded to bottom sheet dialog

### DIFF
--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.components.button.DotoriButton
-import com.dotori.dotori_components.components.calendar.DotoriCalendar
 import com.dotori.dotori_components.theme.DotoriTheme
 import kotlinx.coroutines.*
 
@@ -48,8 +47,7 @@ fun DotoriBottomSheetDialogPreview() {
 
     DotoriBottomSheetDialog(
         sheetContent = {
-            DotoriCalendar()
-//            Text(text = "test")
+            Text(text = "test")
         }
     ) { sheetState ->
         Column(

--- a/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
+++ b/dotori-components/src/main/java/com/dotori/dotori_components/components/bottomsheet/BottomSheetDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.components.button.DotoriButton
+import com.dotori.dotori_components.components.calendar.DotoriCalendar
 import com.dotori.dotori_components.theme.DotoriTheme
 import kotlinx.coroutines.*
 
@@ -23,7 +24,10 @@ fun DotoriBottomSheetDialog(
     content: @Composable (sheetState: ModalBottomSheetState) -> Unit
 ) {
     val sheetBackgroundColor = DotoriTheme.colors.cardBackground
-    val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true
+    )
 
     ModalBottomSheetLayout(
         modifier = modifier,
@@ -44,7 +48,8 @@ fun DotoriBottomSheetDialogPreview() {
 
     DotoriBottomSheetDialog(
         sheetContent = {
-            Text(text = "test")
+            DotoriCalendar()
+//            Text(text = "test")
         }
     ) { sheetState ->
         Column(


### PR DESCRIPTION
## 💡 개요
- DotoriBottomSheetDialog에 skipHalfExpanded 추가

## 🔀 작업내용
- DotoriBottomSheetDialog에 skipHalfExpanded를 추가하여 sheetContent가 절반 이상일 때 잘려서 표시되는 현상 수정

## 🎸 기타
