### PR TITLE
🚀 :: 1.0.8 업데이트

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -9,7 +9,7 @@ object Versions {
 
     const val COMPOSE_VERSION = "1.3.1"
     const val ACTIVITY_COMPOSE = "1.6.1"
-    const val MATERIAL_COMPOSE = "1.4.0-alpha04"
+    const val MATERIAL_COMPOSE = "1.4.0-alpha05"
     const val NAVIGATION_COMPOSE = "2.5.3"
     const val PAGER_COMPOSE = "0.28.0"
     const val LANDSCAPIST_COMPOSE = "2.1.2"


### PR DESCRIPTION
## 💡 개요
- DotoriBottomSheetModal에서 open 할 때 예외 발생

## 🔀 작업내용
- 해당 오류가 수정된 1.4.0-alpha05로 버전 업

## 🎸 기타
